### PR TITLE
Fix typo in notebook

### DIFF
--- a/statistics/Двухвыборочные непараметрические критерии (независимые выборки) stat.non_parametric_tests_ind.ipynb
+++ b/statistics/Двухвыборочные непараметрические критерии (независимые выборки) stat.non_parametric_tests_ind.ipynb
@@ -393,7 +393,7 @@
     "        indices = [(list(index), filter(lambda i: i not in index, range(n))) \\\n",
     "                    for index in itertools.combinations(range(n), n1)]\n",
     "    \n",
-    "    distr = [joined_sample[list(i[0])].ьув() - joined_sample[list(i[1])].mean() \\\n",
+    "    distr = [joined_sample[list(i[0])].mean() - joined_sample[list(i[1])].mean() \\\n",
     "             for i in indices]\n",
     "    return distr"
    ]


### PR DESCRIPTION
I think that actually should be `mean`, not `med`. Why do we subtract `median` from `mean` value? That's strange.